### PR TITLE
Make Governable.updatePauser internal so SM/RM can check if new pauser is manager and revert if so

### DIFF
--- a/src/lib/Governable.sol
+++ b/src/lib/Governable.sol
@@ -28,7 +28,7 @@ abstract contract Governable is Ownable, IGovernable {
 
   /// @notice Update pauser to `_newPauser`.
   /// @param _newPauser The new pauser.
-  function updatePauser(address _newPauser) external {
+  function _updatePauser(address _newPauser) internal {
     if (msg.sender != owner && msg.sender != pauser) revert Unauthorized();
     emit PauserUpdated(_newPauser);
     pauser = _newPauser;

--- a/test/Governable.t.sol
+++ b/test/Governable.t.sol
@@ -8,6 +8,10 @@ contract GovernableHarness is Governable {
   function initGovernable(address owner_, address pauser_) external {
     __initGovernable(owner_, pauser_);
   }
+
+  function updatePauser(address newPauser_) external {
+    _updatePauser(newPauser_);
+  }
 }
 
 contract GovernableTestSetup is TestBase {


### PR DESCRIPTION
Follow-up prs:

Safety Module:
- Check if `pauser == cozySafetyModuleManager` before init governable here https://github.com/Cozy-Finance/cozy-safety-module/blob/main/src/SafetyModule.sol#L50
- Add an external `updatePauser` function which calls the internal `_updatePauser` from `Governable`. It will include the `pauser == cozySafetyModuleManager` check before calling the internal one

Rewards Manager:
- Check if `pauser == cozyManager` before init governable here https://github.com/Cozy-Finance/cozy-safety-module-rewards-manager/blob/main/src/RewardsManager.sol#L69
- Add an external `updatePauser` function which calls the internal `_updatePauser` from `Governable`. It will include the `pauser == cozyManager` check before calling the internal one
